### PR TITLE
check against @encode(BOOL) - fixes #2

### DIFF
--- a/impl/impl/JsonParser/Property.m
+++ b/impl/impl/JsonParser/Property.m
@@ -40,7 +40,7 @@
 }
 
 -(bool)isBoolean{
-    return [self.Type isEqualToString:@"TB"];
+    return (strcmp([[self.Type substringWithRange:NSMakeRange(1, 1)] cStringUsingEncoding:NSASCIIStringEncoding], @encode(BOOL)) == 0);
 }
 
 -(bool)isEnum{


### PR DESCRIPTION
Check the second character against @encode(BOOL) rather than a string literal
